### PR TITLE
Fixes race condition mentioned in #1

### DIFF
--- a/mkpath.js
+++ b/mkpath.js
@@ -20,7 +20,13 @@ var mkpath = function mkpath(dirpath, mode, callback) {
                     if (err) {
                         callback(err);
                     } else {
-                        fs.mkdir(dirpath, mode, callback);
+                        fs.mkdir(dirpath, mode, function (err) {
+                            if (!err || err.code == 'EEXIST') {
+                                callback(null);
+                            } else {
+                                callback(err);
+                            }
+                        });
                     }
                 });
             } else {


### PR DESCRIPTION
If you parallelise directories creation you can be easily caught by a race condition. Imagine 2 parallel processes A and B:

A checks folder /foo -- it doesn't exist
B checks folder /foo -- it doesn't exist
A creates folder /foo -- it succedes
B tries to create folder /foo -- it fails with EEXIST exception, which is propagated to the consumer