### PR TITLE
Strict mode syntax error with octals.

### DIFF
--- a/mkpath.js
+++ b/mkpath.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var fs = require('fs');
 var path = require('path');
 
@@ -6,7 +8,7 @@ var mkpath = function mkpath(dirpath, mode, callback) {
 
     if (typeof mode === 'function' || typeof mode === 'undefined') {
         callback = mode;
-        mode = 0777 & (~process.umask());
+        mode = parseInt('0777', 8) & (~process.umask());
     }
 
     if (!callback) {
@@ -44,7 +46,7 @@ mkpath.sync = function mkpathsync(dirpath, mode) {
     dirpath = path.resolve(dirpath);
 
     if (typeof mode === 'undefined') {
-        mode = 0777 & (~process.umask());
+        mode = parseInt('0777', 8) & (~process.umask());
     }
 
     try {

--- a/package.json
+++ b/package.json
@@ -1,25 +1,25 @@
 {
-    "name": "mkpath",
-    "version": "1.0.0",
-    "author": "Jonathan Rajavuori <jrajav@gmail.com>",
-    "description": "Make all directories in a path, like mkdir -p",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/jrajav/mkpath"
-    },
-    "keywords": [
-        "mkdir",
-        "mkdirp",
-        "directory",
-        "path",
-        "tree"
-    ],
-    "main": "./mkpath",
-    "scripts": {
-        "test": "node node_modules/tap/bin/tap.js ./test/*.js"
-    },
-    "devDependencies": {
-        "tap": "~0.3"
-    },
-    "license": "MIT"
+  "name": "mkpath",
+  "version": "1.0.1",
+  "author": "Jonathan Rajavuori <jrajav@gmail.com>",
+  "description": "Make all directories in a path, like mkdir -p",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jrajav/mkpath"
+  },
+  "keywords": [
+    "mkdir",
+    "mkdirp",
+    "directory",
+    "path",
+    "tree"
+  ],
+  "main": "./mkpath",
+  "scripts": {
+    "test": "node node_modules/tap/bin/tap.js ./test/*.js"
+  },
+  "devDependencies": {
+    "tap": "~0.3"
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
Babel automatically uses strict mode for the transpiled code, so `0777` fails as an invalid number syntax error. 