### PR TITLE
Include only the necessary files in the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "devDependencies": {
     "tap": "~0.3"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "files": [
+    "mkpath.js"
+  ]
 }


### PR DESCRIPTION
For most people, test files and dev. scripts are of no use in the 3rd-party node module.
The suggested change adds the "[files](https://docs.npmjs.com/files/package.json#files)" field to package.json so that only the files necessary for using the module are included into the distributed archive.